### PR TITLE
Ensure channel view card is always fetched

### DIFF
--- a/docs/modules/actions_action_bootstrap_channel.html
+++ b/docs/modules/actions_action_bootstrap_channel.html
@@ -84,7 +84,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ActionFile</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/product-os/jellyfish-plugin-channels/blob/master/lib/actions/action-bootstrap-channel.ts#L182">actions/action-bootstrap-channel.ts:182</a></li>
+							<li>Defined in <a href="https://github.com/product-os/jellyfish-plugin-channels/blob/master/lib/actions/action-bootstrap-channel.ts#L191">actions/action-bootstrap-channel.ts:191</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/lib/actions/action-bootstrap-channel.ts
+++ b/lib/actions/action-bootstrap-channel.ts
@@ -127,7 +127,7 @@ const handler = async (
 	await Promise.all(
 		views.map(async (viewCardBase: any) => {
 			// Save the view card
-			const viewCard = await context.replaceCard(
+			let viewCard = await context.replaceCard(
 				session,
 				viewTypeCard,
 				{
@@ -138,6 +138,15 @@ const handler = async (
 				},
 				viewCardBase,
 			);
+
+			// If the view card already exists and no changes were made, replaceCard returns null,
+			// so we just fetch the card by slug.
+			if (viewCard === null) {
+				viewCard = await context.getCardBySlug(
+					session,
+					`${viewCardBase.slug}@${viewCardBase.version}`,
+				);
+			}
 
 			// And create a link card between the view and the channel
 			return context.replaceCard(


### PR DESCRIPTION
If the view card already exists and no changes were made, replaceCard returns null, so we just fetch the card by slug.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>