### PR TITLE
Use latest version of jellyfish-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@balena/jellyfish-logger": "^4.0.40",
+    "@balena/jellyfish-logger": "^5.0.0",
     "@balena/jellyfish-worker": "^18.8.5",
     "lodash": "^4.17.21",
     "slugify": "^1.6.5"


### PR DESCRIPTION
This major version of the logger no longer handles uncaught exceptions, which would result in mangled and unreadable log messages.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>